### PR TITLE
Let CI workflow run on every change

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,13 +4,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - showcase_3d_printer_anomaly_detection/**
-      - tests/**
-      - .python-version
-      - poetry.lock
-      - project.toml
-      - pyproject.toml
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The main branch is configured to only allow merges from PRs that pass
CI. But if only specific paths trigger the CI workflow the PR is stuck
waiting for the workflow to run.